### PR TITLE
fix(test): use fake timers in flaky progress threshold test

### DIFF
--- a/tests/performance/update-benchmark.test.ts
+++ b/tests/performance/update-benchmark.test.ts
@@ -155,16 +155,21 @@ This is a generated skill for performance testing.
   }
 
   describe('Progress Indicator Threshold', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
     it('should use 2-second default threshold', () => {
-      expect(shouldShowProgress(Date.now())).toBe(false);
-      expect(shouldShowProgress(Date.now() - 1999)).toBe(false);
-      expect(shouldShowProgress(Date.now() - 2000)).toBe(true);
-      expect(shouldShowProgress(Date.now() - 3000)).toBe(true);
+      const now = Date.now();
+      expect(shouldShowProgress(now)).toBe(false);
+      expect(shouldShowProgress(now - 1999)).toBe(false);
+      expect(shouldShowProgress(now - 2000)).toBe(true);
+      expect(shouldShowProgress(now - 3000)).toBe(true);
     });
 
     it('should allow custom threshold', () => {
-      expect(shouldShowProgress(Date.now() - 500, 1000)).toBe(false);
-      expect(shouldShowProgress(Date.now() - 1500, 1000)).toBe(true);
+      const now = Date.now();
+      expect(shouldShowProgress(now - 500, 1000)).toBe(false);
+      expect(shouldShowProgress(now - 1500, 1000)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixes flaky `shouldShowProgress` test in `update-benchmark.test.ts` that failed in CI ([run #21800477217](https://github.com/lwndev/ai-skills-manager/actions/runs/21800477217))
- The test called `Date.now()` separately from the implementation, allowing 1ms+ clock drift to push the 1999ms boundary case over the 2000ms threshold
- Uses `jest.useFakeTimers()` to freeze `Date.now()` so both test and implementation see the same timestamp

## Test plan
- [x] `npm run quality` passes locally (104 suites, 2920 tests)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)