### PR TITLE
chore(documentation): update CHANGELOG.md for 1.8.2 release (CHORE-034)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **CI release notes generation**: Use explicit previous tag for release notes generation to ensure correct diff range
+- **CI release notes generation**: Use explicit previous tag for release notes generation to ensure correct diff range (5ca35da)
 
 ### Compatibility
 

--- a/requirements/chores/CHORE-034-update-changelog-1-8-2.md
+++ b/requirements/chores/CHORE-034-update-changelog-1-8-2.md
@@ -22,13 +22,13 @@ Update `CHANGELOG.md` with a new `[1.8.2]` section documenting all changes merge
 
 ## Acceptance Criteria
 
-- [ ] `CHANGELOG.md` has a new `## [1.8.2] - 2026-03-13` section above `## [1.8.1]`
-- [ ] Jest-to-Vitest migration documented under Changed (FEAT-024, #121)
-- [ ] Managed policy warning for allowed-tools documented under Changed (CHORE-033, #122)
-- [ ] Changelog tracker v2.1.74 bump documented under Compatibility
-- [ ] CI release notes fix documented under Fixed
-- [ ] Entries follow Keep a Changelog format consistent with existing entries
-- [ ] `npm run quality` passes
+- [x] `CHANGELOG.md` has a new `## [1.8.2] - 2026-03-13` section above `## [1.8.1]`
+- [x] Jest-to-Vitest migration documented under Changed (FEAT-024, #121)
+- [x] Managed policy warning for allowed-tools documented under Changed (CHORE-033, #122)
+- [x] Changelog tracker v2.1.74 bump documented under Compatibility
+- [x] CI release notes fix documented under Fixed
+- [x] Entries follow Keep a Changelog format consistent with existing entries
+- [x] `npm run quality` passes
 
 ## Completion
 


### PR DESCRIPTION
## Chore
[CHORE-034](requirements/chores/CHORE-034-update-changelog-1-8-2.md)

## Summary
Updates CHANGELOG.md with a new [1.8.2] section documenting all changes merged since the 1.8.1 release.

## Changes
- Added `## [1.8.2] - 2026-03-13` section with Changed, Fixed, and Compatibility subsections
- Documented Jest-to-Vitest migration (FEAT-024, #121)
- Documented managed policy warning for allowed-tools (CHORE-033, #122)
- Documented CI release notes fix
- Documented changelog tracker v2.1.74 compatibility update
- Added chore document `CHORE-034-update-changelog-1-8-2.md`

## Testing
- [x] Tests pass
- [x] Build succeeds
- [x] Linting passes
- [x] `npm run quality` passes

## Related
- Closes #123

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)