### PR TITLE
chore(documentation): update CHANGELOG.md for 1.8.3 release (CHORE-036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to AI Skills Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.3] - 2026-03-14
+
+### Added
+
+- **ASCII art version banner** (FEAT-025): `asm --version` now displays a branded ASCII art banner with version, tagline, website, and license info. Supports quiet (`-q`), JSON (`-j`), non-TTY, and narrow-terminal fallback modes (#127)
+- **Site repo publish notification** (CHORE-035): Publish workflow now sends a repository dispatch event to notify the site repo on new releases (#125)
+
+### Removed
+
+- **Dead progress bar/spinner code**: Removed unused `formatProgressBar()`, `formatProgressSpinner()` functions and their constants from `update-formatter.ts` (#127)
+
 ## [1.8.2] - 2026-03-13
 
 ### Changed

--- a/requirements/chores/CHORE-036-update-changelog-1-8-3.md
+++ b/requirements/chores/CHORE-036-update-changelog-1-8-3.md
@@ -1,0 +1,38 @@
+# Chore: Update CHANGELOG for 1.8.3
+
+## Chore ID
+
+`CHORE-036`
+
+## GitHub Issue
+
+[#129](https://github.com/lwndev/ai-skills-manager/issues/129)
+
+## Category
+
+`documentation`
+
+## Description
+
+Update `CHANGELOG.md` with a new `[1.8.3]` section documenting all changes merged since the 1.8.2 release. This includes the ASCII art version banner (FEAT-025), site repo publish notification (CHORE-035), and dead progress bar/spinner code removal.
+
+## Affected Files
+
+- `CHANGELOG.md`
+
+## Acceptance Criteria
+
+- [x] `CHANGELOG.md` has a new `## [1.8.3] - 2026-03-14` section above `## [1.8.2]`
+- [x] ASCII art version banner documented under Added (FEAT-025, #127)
+- [x] Site repo publish notification documented under Added (CHORE-035, #125)
+- [x] Dead progress bar/spinner code removal documented under Removed (#127)
+- [x] Entries follow Keep a Changelog format consistent with existing entries
+- [x] `npm run quality` passes
+
+## Completion
+
+**Status:** `Completed`
+
+**Completed:** 2026-03-14
+
+**Pull Request:** [#130](https://github.com/lwndev/ai-skills-manager/pull/130)


### PR DESCRIPTION
## Summary
- Add `[1.8.3]` changelog section documenting all changes since 1.8.2
- ASCII art version banner (FEAT-025, #127)
- Site repo publish notification (CHORE-035, #125)
- Dead progress bar/spinner code removal (#127)

## Test plan
- [x] `npm run quality` passes
- [x] Entries follow Keep a Changelog format
- [x] All milestone issues referenced

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)