### PR TITLE
fix(configuration): strip v prefix from version in publish dispatch (BUG-003)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,12 +66,20 @@ jobs:
         if: inputs.dry-run != true
         run: npm publish --access public
 
-      - name: Notify site repo to auto-update
+      - name: Resolve release version
         if: inputs.dry-run != true && github.event.release.tag_name != ''
+        id: version
+        run: |
+          # Strip leading 'v' from tag (e.g., v1.8.3 -> 1.8.3) — site repo expects plain semver
+          TAG="${{ github.event.release.tag_name }}"
+          echo "semver=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify site repo to auto-update
+        if: steps.version.outputs.semver != ''
         continue-on-error: true
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.SITE_REPO_PAT }}
           repository: lwndev/ai-skills-manager-site
           event-type: cli-release
-          client-payload: '{"version": "${{ github.event.release.tag_name }}"}'
+          client-payload: '{"version": "${{ steps.version.outputs.semver }}"}'

--- a/requirements/bugs/BUG-003-publish-version-prefix.md
+++ b/requirements/bugs/BUG-003-publish-version-prefix.md
@@ -1,0 +1,58 @@
+# Bug: Publish Dispatch Sends v-Prefixed Version
+
+## Bug ID
+
+`BUG-003`
+
+## GitHub Issue
+
+[#131](https://github.com/lwndev/ai-skills-manager/issues/131)
+
+## Category
+
+`logic-error`
+
+## Severity
+
+`medium`
+
+## Description
+
+The publish workflow sends `github.event.release.tag_name` (e.g., `v1.8.3`) directly in the repository dispatch payload to the site repo. The site repo's version validation regex expects plain semver without the `v` prefix, causing the site build to fail at the `resolve version` step.
+
+## Steps to Reproduce
+
+1. Create and publish a GitHub release with tag `v1.8.3`
+2. Publish workflow triggers and reaches the "Notify site repo to auto-update" step
+3. Site repo receives `{"version": "v1.8.3"}`
+4. Site repo's `resolve version` step rejects it with: `Error: Invalid version format: v1.8.3`
+
+## Expected Behavior
+
+The dispatch payload should contain plain semver (e.g., `1.8.3`) without the `v` prefix.
+
+## Actual Behavior
+
+The payload contains the raw tag name `v1.8.3`, which fails the site repo's semver validation regex `^[0-9]+\.[0-9]+\.[0-9]+`.
+
+## Root Cause(s)
+
+1. In `.github/workflows/publish.yml:77`, `github.event.release.tag_name` is interpolated directly into `client-payload` without stripping the leading `v` prefix. Git tags conventionally include the `v` (e.g., `v1.8.3`), but the site repo expects raw semver.
+
+## Affected Files
+
+- `.github/workflows/publish.yml`
+
+## Acceptance Criteria
+
+- [x] Publish workflow strips `v` prefix from tag name before sending dispatch payload (RC-1)
+- [x] Dispatch payload contains plain semver (e.g., `1.8.3` not `v1.8.3`) (RC-1)
+- [x] Workflow YAML passes lint validation (RC-1)
+
+## Completion
+
+**Status:** `Completed`
+
+**Completed:** 2026-03-14
+
+**Pull Request:** [#132](https://github.com/lwndev/ai-skills-manager/pull/132)


### PR DESCRIPTION
## Summary
- Publish workflow was sending `v1.8.3` in the repository dispatch payload to the site repo, but the site repo expects plain semver (`1.8.3`)
- Added a `Resolve release version` step that strips the leading `v` using `${TAG#v}`

## Root Cause
- RC-1: `.github/workflows/publish.yml` interpolated `github.event.release.tag_name` directly into `client-payload` without stripping the `v` prefix

## Test plan
- [x] `npm run quality` passes
- [x] Workflow YAML passes ESLint
- [x] `${TAG#v}` correctly strips `v1.8.3` -> `1.8.3` (bash parameter expansion)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)